### PR TITLE
Update to go 1.16 from 1.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM gcr.io/cloudsql-docker/gce-proxy as cloudsql-proxy
 
-FROM golang:1.14
+FROM golang:1.16
 
 # Copy cloud-proxy binary
 COPY --from=cloudsql-proxy /cloud_sql_proxy /cloud_sql_proxy

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # cloud-sql-proxy-goose
- 
+
 ## Summary
- 
+
 A GitHub Action that uses a Docker image to create a temporary cloud_sql_proxy connection to a GCP CloudSQL Instance and runs a [goose](https://github.com/pressly/goose) command.
 
 ## Inputs


### PR DESCRIPTION
# Code
#### What does your code do?

- Upgrades Dockerfile to use go 1.16

#### Where should the reviewer start?

#### Any background context you want to provide?

Lavender job failed with `unrecognized import path "io/fs": import path does not begin with hostname`
Hopefully it's just a version issue like here: https://github.com/tdewolff/minify/issues/388#issue-830897077

## Checks
##### Pre PR
- [ ] tested changes